### PR TITLE
Fix creation of `1` file in $HOME directory

### DIFF
--- a/home/dot_local/bin/executable_install-program
+++ b/home/dot_local/bin/executable_install-program
@@ -1068,7 +1068,7 @@ async function ensurePackageManager(packageManager) {
       `
     }
     log('info', logStage, 'Ensuring Volt has Node.js runtime available')
-    await $`if ! volta list 2>1 | grep 'runtime node' > /dev/null; then volta install node; fi`
+    await $`if ! volta list 2>&1 | grep 'runtime node' > /dev/null; then volta install node; fi`
   } else if (packageManager === 'pacman') {
     await ensureInstalled('pacman', false)
   } else if (packageManager === 'pipx') {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #12.
- **What is the current behavior?** (You can also link to an open issue here)
Script Creating a File Called `1` in the $HOME Directory
- **What is the new behavior (if this is a feature change)?**
File Called `1` will not be creating in $HOME directory
- **Other information**:
Have not been able to test, will share details of issues in running the script in Fedora, and potential fixes. So, please test the fix before merging