### PR TITLE
Fix compinit path in dot_zshrc

### DIFF
--- a/home/dot_zshrc
+++ b/home/dot_zshrc
@@ -62,7 +62,7 @@ setopt SHARE_HISTORY
 if [ ! -d "$XDG_CACHE_HOME/zsh" ]; then
 	mkdir -p "$XDG_CACHE_HOME/zsh"
 fi
-autoload -U +X compinit && compinit -d "$XDG_CACHE_HOME/zsh/zcompdump-$ZSH_VERSION"
+autoload -U +X compinit && compinit -d "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump-$ZSH_VERSION"
 zstyle ':completion:*:*:*:*:*' menu select
 zstyle ':completion:*' cache-path "$XDG_CACHE_HOME/zsh/zcompcache"
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Updates the PATH used for `compinit` in .zshrc.

- **Other information**:
Relates to #46 and #47.