### PR TITLE
Fix `provision.sh`: pacman command

### DIFF
--- a/scripts/partials/basic-deps
+++ b/scripts/partials/basic-deps
@@ -11,8 +11,7 @@ if ! command -v curl > /dev/null || ! command -v git > /dev/null || ! command -v
         sudo yum install -y curl expect git rsync
     elif command -v pacman > /dev/null; then
         # @description Ensure `curl`, `expect`, `git`, and `rsync` are installed on Archlinux
-        sudo pacman update
-        sudo pacman -Sy curl expect git rsync
+        sudo pacman -Syu base-devel curl expect git rsync procps-ng file
     elif command -v zypper > /dev/null; then
         # @description Ensure `curl`, `expect`, `git`, and `rsync` are installed on OpenSUSE
         sudo zypper install -y curl expect git rsync

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -265,8 +265,7 @@ if ! command -v curl > /dev/null || ! command -v git > /dev/null || ! command -v
         sudo yum install -y curl expect git rsync procps-ng file
     elif command -v pacman > /dev/null; then
         # @description Ensure `base-devel`, `curl`, `expect`, `git`, `rsync`, `procps-ng`, and `file` are installed on Archlinux
-        sudo pacman update
-        sudo pacman -Sy base-devel curl expect git rsync procps-ng file
+        sudo pacman -Syu base-devel curl expect git rsync procps-ng file
     elif command -v zypper > /dev/null; then
         # @description Ensure `curl`, `expect`, `git`, `rsync`, `procps`, and `file` are installed on OpenSUSE (as well as the devel_basis pattern)
         sudo zypper install -yt pattern devel_basis


### PR DESCRIPTION
1. Remove invalid `pacman update` command
2. Add `--upgrade` to prevent partial upgrades which are unsupported in Arch Linux

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Faulty, pacman doesn't have an `update` sub-command and partial upgrades may break the system.

- **What is the new behavior (if this is a feature change)?**
Correct without invalid commands and full upgrade.

- **Other information**:
None
