### PR TITLE
Fix incorrect path for betelgeuse

### DIFF
--- a/home/.chezmoiscripts/universal/run_onchange_after_19-theme-files.sh.tmpl
+++ b/home/.chezmoiscripts/universal/run_onchange_after_19-theme-files.sh.tmpl
@@ -29,8 +29,8 @@ if [ ! -d /usr/local/share ]; then
 fi
 
 ### Copy theme files over to /usr/local/share
-if [ -d "$HOME/.local/src/{{ .theme | lower }}/share" ]; then
-    logg info 'Copying ~/.local/src/{{ .theme | lower }}/share to /usr/local/share'
+if [ -d "$HOME/.local/{{ .theme | lower }}/share" ]; then
+    logg info 'Copying ~/.local/{{ .theme | lower }}/share to /usr/local/share'
     sudo rsync --chown=root:root --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r -artvu --inplace "${XDG_DATA_HOME:-$HOME/.local/share}/betelgeuse/share/" "/usr/local/share/" > /dev/null
 else
     logg warn '~/.local/share/betelgeuse/share is missing'


### PR DESCRIPTION
The script was actually trying to copy `~/.local/share/src/*`, resulting in this error (which incidentally shows the correct path to copy):

```
 ◆  WARNING  ~/.local/share/betelgeuse/share is missing
```

This affects all theme related changes, like the background being blank when tested in Fedora.