### PR TITLE
Plugin installation - ID and command to install Copolit

### DIFF
--- a/software.yml
+++ b/software.yml
@@ -10780,6 +10780,7 @@ softwarePlugins:
       - system-images;android-33;google-tv;x86
       - system-images;android-33;google_apis;x86_64
       - system-images;android-33;google_apis_playstore;x86_64
+      # - com.github.copilot # Unable to find a way to install automatically using CLI
   composer:
     cmd: null
     plugins:
@@ -10831,6 +10832,10 @@ softwarePlugins:
       - dlvhdr/gh-dash
       - github/gh-net
       - mislav/gh-cp
+  intellij-idea-ce:
+    cmd: bash -c 'idea.sh installPlugins "{PLUGIN}"'
+    plugins:
+      - com.github.copilot
   helm:
     cmd: bash -c '{PLUGIN}'
     plugins:
@@ -10952,7 +10957,16 @@ softwarePlugins:
       - vagrant-vmware-desktop
       - vagrant-xenserver
   visual-studio:
-    cmd: null
+    cmd: null # VSIXInstaller.exe can be used to install a local file. The first step is to download the plugin file. https://gist.github.com/ScottHutchinson/b22339c3d3688da5c9b477281e258400
     plugins:
+      - GitHub.copilotvs
       - TemplateStudio.TemplateStudioForWinUICs
       - lepo.wpf-ui
+  vscode::
+    cmd: bash -c 'if ! code --list-extensions | grep "{PLUGIN}" > /dev/null; then code --install-extension "{PLUGIN}"; fi'
+    plugins:
+      - GitHub.copilot
+  vscodium:
+    cmd: bash -c 'if ! codium --list-extensions | grep "{PLUGIN}" > /dev/null; then codium --install-extension "{PLUGIN}"; fi'
+    plugins:
+      - GitHub.copilot


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Changes to install GitHub Copilot plugin

- **Other information**:
Fixes #66.
**Note**:
* CLI method to install the plugin for Android Studio in not available. It does not use the Idea IDE method.
* For Visual Studio, installation is possible after downloading a copy of the plugin. This can be performed using Powershell but before doing that, need to know if downloading is possible using any of the other tools we use to run installation. This is because the URL keeps changing.