### PR TITLE
Fix `install-program`: Wait for snap to finish seeding

### DIFF
--- a/home/dot_local/bin/executable_install-program
+++ b/home/dot_local/bin/executable_install-program
@@ -1155,6 +1155,8 @@ async function ensurePackageManager(packageManager) {
     const snap = which.sync('snap', { nothrow: true })
     if (snap) {
       runCommand('Check info for core snap package', `sudo snap info core`)
+      // Required: https://snapcraft.io/docs/troubleshooting#heading--early
+      runCommand('Ensuring snap is seeded', `sudo snap wait system seed.loaded`)
       runCommand('Ensuring snap core is installed', `sudo snap install core`)
     } else {
       log('warn', logStage, 'Snap installation sequence completed but the snap bin is still not available')


### PR DESCRIPTION
Snap needs to seed itself into the system before it can perform any operations, such as installing the snap core. If done too early it will emit an error like this:

```
error: too early for operation, device not yet seeded or device model not acknowledged
```

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a major bug fix since the entire `install-program` script stops if snap fails during the install core command.
