### PR TITLE
Fix bug report labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReport.yml
+++ b/.github/ISSUE_TEMPLATE/BugReport.yml
@@ -1,7 +1,7 @@
 ---
 name: 🐛 Bug Report
 description: Stumbled upon an error? Submit a bug report.
-labels: [question]
+labels: [bug]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
They should be labelled as `bug`s, not `question`s!

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Meta update for GitHub issue template