### PR TITLE
Load homebrew before doing gcc installed check

### DIFF
--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -219,8 +219,10 @@ ensurePackageManagerHomebrew() {
 
 ### Ensures gcc is installed
 ensureGcc() {
-  if command -v brew > /dev/null; then
-    if ! brew list | grep gcc > /dev/null; then
+  # Eval homebrew before checking if gcc is installed
+  loadHomebrew
+  if command -v brew >/dev/null; then
+    if ! brew list | grep gcc >/dev/null; then
       logg info 'Installing Homebrew gcc' && brew install --quiet gcc
     else
       logg info 'Homebrew gcc is available'


### PR DESCRIPTION
This install was failing on ubuntu because we needed homebrew loaded into our environment before running a brew list check.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
